### PR TITLE
Doc: Update you correct GitHub username in Contributing.md documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,4 +237,4 @@ Your contributions make Vyoma UI better for everyone. Whether you're fixing a bu
 
 **Happy coding!** 🚀
 
-Questions? Reach out to [@srijanbaniyal](https://github.com/srijanbaniyal) or open an issue ✨.
+Questions? Reach out to [@Srijan-Baniyal](https://github.com/Srijan-Baniyal) or open an issue ✨.


### PR DESCRIPTION
Hi, while reading the readme documentation, I came across your incorrect/old username, it was shown as **srijanbaniyal** in the hyperlink, so clicking on it gave 404. 

- Fixed with your correct username.

<kbd><img width="1162" height="181" alt="Screenshot 2025-10-23 at 9 39 50 PM" src="https://github.com/user-attachments/assets/a5bd9ae3-9dbb-4c4a-b95c-ff1253e83aac" /></kbd>
